### PR TITLE
Enable Trilium to use RFC 5870 geo-URIs

### DIFF
--- a/packages/ckeditor5-build-balloon-block/src/ckeditor.ts
+++ b/packages/ckeditor5-build-balloon-block/src/ckeditor.ts
@@ -282,7 +282,7 @@ export default class BalloonEditor extends BalloonEditorBase {
 		},
 		link: {
 			defaultProtocol: 'https://',
-			allowedProtocols: ['https?', 'tel', 'sms', 'sftp', 'smb', 'slack', 'file', 'zotero']
+			allowedProtocols: ['https?', 'tel', 'sms', 'sftp', 'smb', 'slack', 'file', 'zotero', 'geo']
 		},
 		// This value must be kept in sync with the language defined in webpack.config.js.
 		language: 'en'

--- a/packages/ckeditor5-build-trilium/src/config.ts
+++ b/packages/ckeditor5-build-trilium/src/config.ts
@@ -242,7 +242,7 @@ export const COMMON_SETTINGS = {
 			'http', 'https', 'ftp', 'ftps', 'mailto', 'data', 'evernote', 'file', 'facetime', 'gemini', 'git',
 			'gopher', 'imap', 'irc', 'irc6', 'jabber', 'jar', 'lastfm', 'ldap', 'ldaps', 'magnet', 'message',
 			'mumble', 'nfs', 'onenote', 'pop', 'rmi', 's3', 'sftp', 'skype', 'sms', 'spotify', 'steam', 'svn', 'udp',
-			'view-source', 'vlc', 'vnc', 'ws', 'wss', 'xmpp', 'jdbc', 'slack', 'tel', 'smb', 'zotero'
+			'view-source', 'vlc', 'vnc', 'ws', 'wss', 'xmpp', 'jdbc', 'slack', 'tel', 'smb', 'zotero', 'geo'
   		]
 	},
 	// This value must be kept in sync with the language defined in webpack.config.js.

--- a/packages/ckeditor5-link/src/utils.ts
+++ b/packages/ckeditor5-link/src/utils.ts
@@ -41,7 +41,8 @@ const PROTOCOL_REG_EXP = /^((\w+:(\/{2,})?)|(\W))/i;
 const DEFAULT_LINK_PROTOCOLS = [
 	'https?',
 	'ftps?',
-	'mailto'
+	'mailto',
+	'geo'
 ];
 
 /**


### PR DESCRIPTION
### Support for RFC 5870 geo-URIs

Type: Feature

---

### Additional information

Added the geo-scheme to allowed-protocols-arrays to enable [TriliumNext/Notes](https://github.com/TriliumNext/Notes) to use the Geo-URIs (hrefs to locations) in its notes. Since the scheme is standardized via [RFC 5870](https://www.rfc-editor.org/rfc/rfc5870) I assume it is safe and should be allowed.
A pull request to utilize this feature will be opened in [TriliumNext/Notes](https://github.com/TriliumNext/Notes).
