### PR TITLE
Allowing autolink to recognize local addresses such as http://localho…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,49 @@
 #!/usr/bin/env bash
 
-if [ $# -ne 1 ]; then
-	echo "Usage: $0 /path/to/Notes/repo"
-	exit 1
+# Function to display help message
+display_help() {
+    echo "Usage: $0 </absolute_path/to/TriliumNext/Notes_repo>"
+        echo ""
+    echo "Options:"
+    echo "  --help    Display this help message"
+        echo ""
+    exit 0
+}
+
+# Check if an argument is provided, otherwise show warning and help
+if [ $# -eq 0 ]; then
+        echo ""
+    echo "  Error: No argument provided."
+        echo ""
+    display_help
 fi
+
+# Check if the user asked for help
+if [ "$1" == "--help" ]; then
+    display_help
+fi
+
+# Check if the argument is an absolute path
+echo -n "🔍 Checking: Argument is an absolute path... "
+if [[ "$1" != /* ]]; then
+    echo "  Failed"
+    echo "Error: The argument must be an absolute path."
+    exit 1
+fi
+echo "  Passed"
+
+# Check if the path is an npm project (contains package.json)
+echo -n "🔍 Checking: Path contains a valid npm project... "
+if [ -f "$1/package.json" ]; then
+    echo "  Passed"
+else
+    echo "  Failed"
+    echo "Error: This is not an npm project (package.json not found)."
+    exit 1
+fi
+
+# If everything is correct, print success message
+echo "🎉 Success: Valid npm project path -> $1"
 
 cd packages/ckeditor5-build-trilium
 yarn build

--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -41,12 +41,14 @@ const URL_REG_EXP = new RegExp(
 				'(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))' +
 				'|' +
 				'(' +
-					// Do not allow `www.foo` - see https://github.com/ckeditor/ckeditor5/issues/8050.
-					'((?!www\\.)|(www\\.))' +
+					// ~~Do not allow `www.foo` - see https://github.com/ckeditor/ckeditor5/issues/8050.~~~
+					// Re-enabling it... Why not?
+					// '((?!www\\.)|(www\\.))' +
 					// Host & domain names.
-					'(?![-_])(?:[-_a-z0-9\\u00a1-\\uffff]{1,63}\\.)+' +
+					'(?![-_])(?:[-_a-z0-9\\u00a1-\\uffff]{1,63})' +
+					'(?:\\.[-_a-z0-9\\u00a1-\\uffff]{2,63})*' +
 					// TLD identifier name.
-					'(?:[a-z\\u00a1-\\uffff]{2,63})' +
+					'(?:\\.[a-z\\u00a1-\\uffff]{2,63})*' +
 				')' +
 			')' +
 			// port number (optional)

--- a/packages/ckeditor5-markdown-gfm/src/html2markdown/html2markdown.ts
+++ b/packages/ckeditor5-markdown-gfm/src/html2markdown/html2markdown.ts
@@ -19,8 +19,9 @@ const autolinkRegex = /* #__PURE__ */ new RegExp(
 	/\b(?:(?:https?|ftp):\/\/|www\.)/.source +
 
 	// Domain name.
-	/(?![-_])(?:[-_a-z0-9\u00a1-\uffff]{1,63}\.)+(?:[a-z\u00a1-\uffff]{2,63})/.source +
-
+	// at least one string, and then as much as needed starting with a dot
+	// finally, the TLD identifier name, made optional
+	/(?![-_])(?:[-_a-z0-9\u00a1-\uffff]{1,63})(?:\.[-_a-z0-9\u00a1-\uffff]{2,63})*(?:\.[a-z\u00a1-\uffff]{2,63})*/.source +
 	// The rest.
 	/(?:[^\s<>]*)/.source,
 	'gi'


### PR DESCRIPTION
Type : enhancement

Description:

Autolink Regex was modified to allow any kind of url:
- unlocking previous safeguards (`www` was not allowed before)
- authorizing local hosts like `http://localhost` 

