### PR TITLE
fix(image): allow image captions to include footnotes

### DIFF
--- a/packages/ckeditor5-image/src/imagecaption/imagecaptionediting.ts
+++ b/packages/ckeditor5-image/src/imagecaption/imagecaptionediting.ts
@@ -66,8 +66,12 @@ export default class ImageCaptionEditing extends Plugin {
 		if ( !schema.isRegistered( 'caption' ) ) {
 			schema.register( 'caption', {
 				allowIn: 'imageBlock',
-				allowContentOf: '$block',
-				isLimit: true
+				inheritAllFrom: '$block',
+				// To allow complex content like footnotes
+				allowContentOf: '$root',
+				// Prevent block structures that lead to visual errors
+				disallowChildren: ['paragraph', 'pageBreak'],
+				isLimit: true,
 			} );
 		} else {
 			schema.extend( 'caption', {


### PR DESCRIPTION
**Overview**
The fix is tested and works as expected.

Adding Captions to images is now possible.

**Solution description**: 
Image Captions where a textfield inside trilium-ckeditor5/packages/ckeditor5-image/
Which text is allowed is controled via the ckeditor5 schema:
https://ckeditor.com/docs/ckeditor5/latest/framework/deep-dive/schema.html#content-elements
 Using that info I puzzeled together a solution

![image](https://github.com/user-attachments/assets/f4424e1d-7551-491c-afad-3fa9ba9b8917)
