### PR TITLE
feat(build): make build.sh robust to relative paths and early failures

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,8 +6,8 @@ set -e
 set -u
 
 if [ $# -ne 1 ]; then
-    echo "Usage: $0 /path/to/Notes/repo"
-    exit 1
+	echo "Usage: $0 /path/to/Notes/repo"
+	exit 1
 fi
 
 # convert relative paths to absolute paths
@@ -24,5 +24,5 @@ cp -v build/ckeditor.* "$TARGET_DIR/libraries/ckeditor"
 
 mkdir -p "$TARGET_DIR/libraries/ckeditor/translations"
 for language in es de fr zh-cn zh ro; do
-    cp -v "build/translations/$language.js" "$TARGET_DIR/libraries/ckeditor/translations/$language.js"
+	cp -v "build/translations/$language.js" "$TARGET_DIR/libraries/ckeditor/translations/$language.js"
 done

--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,28 @@
 #!/usr/bin/env bash
 
+# exit immediately on error to avoid hidden failures
+set -e
+# exit if an undefined variable is used to catch bugs early
+set -u
+
 if [ $# -ne 1 ]; then
-	echo "Usage: $0 /path/to/Notes/repo"
-	exit 1
+    echo "Usage: $0 /path/to/Notes/repo"
+    exit 1
 fi
 
-cd packages/ckeditor5-build-trilium
-yarn build
-cp -v build/ckeditor.* $1/libraries/ckeditor
+# convert relative paths to absolute paths
+TARGET_DIR=$(realpath "$1")
 
-mkdir -p $1/libraries/ckeditor/translations
-for language in es de es fr zh-cn zh ro; do
-	cp -v build/translations/$language.js $1/libraries/ckeditor/translations/$language.js
+# ensure script is location-independent
+SCRIPT_DIR="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
+
+cd "$SCRIPT_DIR/packages/ckeditor5-build-trilium"
+
+yarn build
+
+cp -v build/ckeditor.* "$TARGET_DIR/libraries/ckeditor"
+
+mkdir -p "$TARGET_DIR/libraries/ckeditor/translations"
+for language in es de fr zh-cn zh ro; do
+    cp -v "build/translations/$language.js" "$TARGET_DIR/libraries/ckeditor/translations/$language.js"
 done


### PR DESCRIPTION
Fix for a quirk of the build script that resulted in hours lost:

For build.sh
- Resolve input path to absolute with realpath
- Make script location-independent using realpath on script path
- Add set -e and set -u to fail fast on errors and unset variables
- Improve indentation for consistency